### PR TITLE
Update architecture and build SDK version

### DIFF
--- a/android/build.properties
+++ b/android/build.properties
@@ -1,3 +1,4 @@
-titanium.platform=/Users/timpoulsen/Library/Application Support/Titanium/mobilesdk/osx/3.5.0.GA/android
-android.platform=/Users/timpoulsen/android-sdk/platforms/android-21
-google.apis=/Users/timpoulsen/android-sdk/add-ons/addon-google_apis-google-21
+titanium.platform=/Users/timpoulsen/Library/Application Support/Titanium/mobilesdk/osx/5.1.2.GA/android
+android.platform=/Users/timpoulsen/Library/Android/sdk/platforms/android-23
+google.apis=/Users/timpoulsen/Library/Android/sdk/add-ons/addon-google_apis-google-23
+android.ndk=/Users/timpoulsen/android-ndk-r10e

--- a/android/manifest
+++ b/android/manifest
@@ -2,9 +2,9 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 0.1.0
+version: 0.1.1
 apiversion: 2
-architectures: armeabi armeabi-v7a x86
+architectures: armeabi armeabi-v7a x86 x86_64
 description: Take a picture at the specified size.
 author: Tim Poulsen
 license: Apache License Version 2.0
@@ -15,4 +15,4 @@ name: picatsize
 moduleid: com.skypanther.picatsize
 guid: 9e551de1-fd22-46d0-8266-a825ac0de882
 platform: android
-minsdk: 3.5.0.GA
+minsdk: 5.0.0.GA


### PR DESCRIPTION
Resolves the "text relocations" crash on an Android 6 device
